### PR TITLE
making the shadow customizable

### DIFF
--- a/lib/hawk_fab_menu.dart
+++ b/lib/hawk_fab_menu.dart
@@ -8,13 +8,15 @@ class HawkFabMenu extends StatefulWidget {
   final Widget body;
   final List<HawkFabMenuItem> items;
   final double blur;
+  final Color shadowColor;
   final AnimatedIconData icon;
   final Color fabColor;
   final Color iconColor;
   HawkFabMenu({
-    @required this.body,
+    this.body,
     @required this.items,
     this.blur: 5.0,
+    this.shadowColor: Colors.black12,
     this.icon,
     this.fabColor,
     this.iconColor,
@@ -142,7 +144,7 @@ class _HawkFabMenuState extends State<HawkFabMenu>
           sigmaY: this.widget.blur,
         ),
         child: Container(
-          color: Colors.black12,
+          color: widget.shadowColor,
         ),
       ),
     );


### PR DESCRIPTION
-->making the shadow customizable because some use cases don't require it at all, and also having the possibility to choose the color and its opacity is a nice addition to the package

--> i also removed @required from the 'body' because in some situations the body is not required for example when using the package inside a stack and just want the buttons (my use case switch dynamically between a normal floating button and the package)